### PR TITLE
Add missing exceptions flag for Linux compilation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
 		],
 		'cflags_cc!': ['-std=c++11'],
 		'defines': ['NAPI_ENABLE_CPP_EXCEPTIONS'],
-		
+
 		'conditions': [
 			['OS=="mac"', {
 				'defines': ['LINK_PLATFORM_MACOSX=1'],
@@ -22,7 +22,8 @@
 				}
 			}],
 			['OS=="linux"', {
-				'defines': ['LINK_PLATFORM_LINUX=1', 'NAPI_ENABLE_CPP_EXCEPTIONS']
+				'defines': ['LINK_PLATFORM_LINUX=1'],
+				'cflags_cc': ['-fexceptions']
 			}],
 			['OS=="win"', {
 				'defines': ['LINK_PLATFORM_WINDOWS=1', '_WIN32_WINNT=0x0501','NAPI_DISABLE_CPP_EXCEPTIONS'],


### PR DESCRIPTION
Added missing flag for exception enabling.

Note that I also suspect that the NAPI_ENABLE_CPP_EXCEPTIONS environment variable should be replaced with NAPI_CPP_EXCEPTIONS according to the node-addon-api sources:
https://github.com/nodejs/node-addon-api/blob/ef16dfb4a2f7efbb2bd5704a517b383c98c5a3c7/napi.h#L28